### PR TITLE
Implement basic ChatGPT interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ChatGPT_API
 ChatGPT API Interface is a customizable platform designed for seamless interaction with OpenAI's ChatGPT API. It offers advanced configuration options, adjustable parameters, and a user-friendly interface for enhanced AI-driven conversations.
+
+## Instalación
+
+```bash
+npm install
+```
+
+Configura una variable de entorno `OPENAI_API_KEY` con tu clave de la API y, opcionalmente, edita `config.json` para ajustar los parámetros por defecto.
+
+## Uso
+
+```bash
+npm start
+```
+
+Abre `http://localhost:3000` en el navegador para acceder a la interfaz.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,8 @@
+{
+  "model": "gpt-3.5-turbo",
+  "temperature": 0.7,
+  "max_tokens": 150,
+  "top_p": 1.0,
+  "frequency_penalty": 0.0,
+  "presence_penalty": 0.0
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chatgpt_api",
+  "version": "1.0.0",
+  "description": "ChatGPT API Interface is a customizable platform designed for seamless interaction with OpenAI's ChatGPT API. It offers advanced configuration options, adjustable parameters, and a user-friendly interface for enhanced AI-driven conversations.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.2",
+    "openai": "^4.48.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ChatGPT Interfaz</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+    #chat { border: 1px solid #ccc; padding: 10px; height: 400px; overflow-y: scroll; }
+    .msg { margin: 5px 0; }
+    #params { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Interfaz ChatGPT</h1>
+  <div id="chat"></div>
+  <input id="message" placeholder="Escribe tu mensaje" style="width:80%">
+  <button id="send">Enviar</button>
+  <div id="params">
+    <label>Temperature: <input id="temperature" type="number" step="0.1" min="0" max="2" value="0.7"></label>
+    <label>Max tokens: <input id="max_tokens" type="number" value="150"></label>
+  </div>
+  <script>
+  async function sendMessage() {
+    const msg = document.getElementById('message').value;
+    document.getElementById('message').value = '';
+    appendMsg('Usuario', msg);
+
+    const params = {
+      temperature: parseFloat(document.getElementById('temperature').value),
+      max_tokens: parseInt(document.getElementById('max_tokens').value, 10)
+    };
+    const res = await fetch('/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        messages: [{ role: 'user', content: msg }],
+        options: params
+      })
+    });
+    const data = await res.json();
+    const reply = data.choices && data.choices[0].message.content;
+    if (reply) appendMsg('ChatGPT', reply);
+  }
+
+  function appendMsg(role, text) {
+    const div = document.createElement('div');
+    div.className = 'msg';
+    div.textContent = `${role}: ${text}`;
+    document.getElementById('chat').appendChild(div);
+  }
+
+  document.getElementById('send').addEventListener('click', sendMessage);
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const cors = require('cors');
+const { Configuration, OpenAIApi } = require('openai');
+require('dotenv').config();
+
+const app = express();
+app.use(express.json());
+app.use(cors());
+
+const CONFIG_PATH = path.join(__dirname, 'config.json');
+let userConfig = {};
+
+function loadConfig() {
+  try {
+    const data = fs.readFileSync(CONFIG_PATH, 'utf8');
+    userConfig = JSON.parse(data);
+  } catch (err) {
+    console.error('Failed to load config:', err);
+    userConfig = {};
+  }
+}
+
+loadConfig();
+
+const configuration = new Configuration({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+const openai = new OpenAIApi(configuration);
+
+app.get('/config', (req, res) => {
+  res.json(userConfig);
+});
+
+app.post('/chat', async (req, res) => {
+  if (!process.env.OPENAI_API_KEY) {
+    return res.status(500).json({ error: 'API key not configured.' });
+  }
+
+  const { messages, options } = req.body;
+  const params = { ...userConfig, ...(options || {}) };
+  try {
+    const completion = await openai.createChatCompletion({
+      model: params.model,
+      messages,
+      temperature: params.temperature,
+      max_tokens: params.max_tokens,
+      top_p: params.top_p,
+      frequency_penalty: params.frequency_penalty,
+      presence_penalty: params.presence_penalty,
+    });
+    res.json(completion.data);
+  } catch (err) {
+    console.error('OpenAI error:', err.response ? err.response.data : err.message);
+    res.status(500).json({ error: 'Failed to fetch completion.' });
+  }
+});
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server to connect with OpenAI
- create config.json for default parameters
- create minimal client UI with HTML/JS
- update README with install and usage instructions
- add package.json and .gitignore

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850031cb1f883308352c8b872fe91ec